### PR TITLE
restore circle cache (for package-lock.json instead of package.json)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node
+      - image: circleci/node:8.11.3
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,17 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
       - run:
           name: Install Firebase Tools
           command: npm install --prefix=./firebase-deploy firebase-tools


### PR DESCRIPTION
**DO NOT MERGE WITHOUT CHECKING WITH ME**

follow up to #47 which was to see if the cache is the problem, we want to checksum on package-lock.json instead of package.json because package-lock is more indicative of any dependancy changes whereas caching package.json could cause issues